### PR TITLE
Disable websocket compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # gRPC-Web: Typed Frontend Development
-
+This is patched fork from [improbable-eng/grpc-web](https://github.com/improbable-eng/grpc-web)
+Patch removes web-socket compression due IOS 15 problems
 
 [![CircleCI](https://circleci.com/gh/improbable-eng/grpc-web/tree/master.svg?style=svg)](https://circleci.com/gh/improbable-eng/grpc-web/tree/master)
 [![Sauce Test Status](https://app.saucelabs.com/buildstatus/ImprobableEngBot)](https://app.saucelabs.com/u/ImprobableEngBot)

--- a/go/grpcweb/wrapper.go
+++ b/go/grpcweb/wrapper.go
@@ -169,6 +169,7 @@ func (w *WrappedGrpcServer) HandleGrpcWebsocketRequest(resp http.ResponseWriter,
 	wsConn, err := websocket.Accept(resp, req, &websocket.AcceptOptions{
 		InsecureSkipVerify: true, // managed by ServeHTTP
 		Subprotocols:       []string{"grpc-websockets"},
+		CompressionMode:    websocket.CompressionDisabled,
 	})
 	if err != nil {
 		grpclog.Errorf("Unable to upgrade websocket request: %v", err)


### PR DESCRIPTION
It seems that iOS 15 does not support permessage-deflate